### PR TITLE
Fix deserializing mps references that contain an f

### DIFF
--- a/runtime/src/main/kotlin/References.kt
+++ b/runtime/src/main/kotlin/References.kt
@@ -25,7 +25,7 @@ class MPSCompatibleNodeReference(private val modelId: String, private val nodeId
     }
 }
 
-private val MPS_NODE_REF_REGEX =  Regex("""mps-node:r:([abcde0-9\-]*)\((\S*)\)\/([0-9]*)""")
+private val MPS_NODE_REF_REGEX =  Regex("""mps-node:r:([abcdef0-9\-]*)\((\S*)\)\/([0-9]*)""")
 class MPSNodeReferenceDeserializer {
     companion object : INodeReferenceSerializer {
         override fun deserialize(serialized: String): INodeReference? {


### PR DESCRIPTION
To fix "No deserializer found for: mps-node:r:9e0bf89b-7c83-426e-8e13-cd21fab7b94a(MethodConfiguration)/5347529599084880993"