### PR TITLE
Don't throw NPE if accessing null references

### DIFF
--- a/runtime/src/main/kotlin/Language.kt
+++ b/runtime/src/main/kotlin/Language.kt
@@ -33,7 +33,7 @@ class MPSLanguageRegistry: IConceptReferenceSerializer {
             language.getConcepts().forEach { conceptsById[it.getUID()] = it }
         }
         fun <T : INodeHolder>getInstance(iNode: INode): T? {
-            return (iNode.concept as AbstractConcept<T>).createInstance(iNode)
+            return (iNode?.concept as? AbstractConcept<T>)?.createInstance(iNode)
         }
         fun getConceptById(id: String):AbstractConcept<*>? {
             return conceptsById[id] as? AbstractConcept<*>


### PR DESCRIPTION
```
Given I have a concept `Car` which has a nullable reference `owner`
And my `aCar` has no owner
When I call `aCar.getOwner()`, I erroneously got a NullPointerException
Because it is calling `MPSLanguageRegistry.Companion.getInstance(getINode().getReferenceTarget("owner"))`
It now returns null instead of throwing the NPE
```

thanks to christoph and sameh for debugging this together