### PR TITLE
Fix deserializing foreign nodes

### DIFF
--- a/runtime/src/main/kotlin/References.kt
+++ b/runtime/src/main/kotlin/References.kt
@@ -25,7 +25,7 @@ class MPSCompatibleNodeReference(private val modelId: String, private val nodeId
     }
 }
 
-private val MPS_NODE_REF_REGEX =  Regex("""mps-node:r:([abcdef0-9\-]*)\((\S*)\)\/([0-9]*)""")
+private val MPS_NODE_REF_REGEX =  Regex("""mps-node:(r:[abcdef0-9\-]*)\((\S*)\)\/([0-9]*)""")
 class MPSNodeReferenceDeserializer {
     companion object : INodeReferenceSerializer {
         override fun deserialize(serialized: String): INodeReference? {


### PR DESCRIPTION
it actually deserialized the model ids to be the some uuid, but the model has the id spelled as `r:some-uuid`