### PR TITLE
Use new itemis cloud maven repository

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -12,5 +12,5 @@ subprojects {
     }
 }
 
-ext["mpsVersion"] = "2020.3.5"
-ext["mpsExtensionsVersion"] = "2020.3.2293.481eecd"
+ext["mpsVersion"] = "2020.3.6"
+ext["mpsExtensionsVersion"] = "2020.3.2448.814f11e"

--- a/mps/build.gradle.kts
+++ b/mps/build.gradle.kts
@@ -1,16 +1,16 @@
 buildscript {
     repositories {
-        maven { url = uri("https://projects.itemis.de/nexus/content/repositories/mbeddr") }
+        maven { url = uri("https://artifacts.itemis.cloud/repository/maven-mps") }
         mavenCentral()
     }
 
     dependencies {
-        classpath("de.itemis.mps:mps-gradle-plugin:1.6.281.3790039")
+        classpath("de.itemis.mps:mps-gradle-plugin:1.9.315.4487934")
     }
 }
 
 plugins {
-    id("download-jbr") version "1.6.281.3790039"
+    id("download-jbr") version "1.9.315.4487934"
     `maven-publish`
 }
 
@@ -23,7 +23,7 @@ repositories {
             password = project.findProperty("gpr.key") as String? ?: System.getenv("TOKEN")
         }
     }
-    maven { url = uri("https://projects.itemis.de/nexus/content/repositories/mbeddr") }
+    maven { url = uri("https://artifacts.itemis.cloud/repository/maven-mps") }
 }
 
 val mpsStubs by configurations.creating
@@ -39,7 +39,7 @@ val mpsExtensionsVersion : String by project
 
 
 downloadJbr {
-    jbrVersion = "11_0_10-b1145.96"
+    jbrVersion = "11_0_10-b1341.41"
 }
 
 dependencies {

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,6 +1,6 @@
 pluginManagement {
     repositories {
-        maven { url = uri("https://projects.itemis.de/nexus/content/repositories/mbeddr") }
+        maven { url = uri("https://artifacts.itemis.cloud/repository/maven-mps") }
         gradlePluginPortal()
     }
 }


### PR DESCRIPTION
Transition to the new maven repository at `https://artifacts.itemis.cloud/repository/maven-mps`